### PR TITLE
Add govuk repos to install script

### DIFF
--- a/GH_REPOS
+++ b/GH_REPOS
@@ -27,4 +27,3 @@ pp-puppet
 puppet-backdrop
 puppet-limelight
 stageprompt
-signonotron2

--- a/GOV_REPOS
+++ b/GOV_REPOS
@@ -1,0 +1,2 @@
+signonotron2
+static

--- a/install.sh
+++ b/install.sh
@@ -92,3 +92,10 @@ while read repo; do
   fetch_repo "$repo" "$GITHUB_ENT"
 done < "GHE_REPOS"
 
+if [ -n "$GOVUK_DEPS" ]; then
+    status "Reading list of GOV.UK repositories from GOV_REPOS and fetching from GitHub"
+    while read repo; do
+        fetch_repo "$repo" "$GITHUB_PUBLIC"
+    done < "GOV_REPOS"
+fi
+


### PR DESCRIPTION
Add flag for also checking out GOV.UK repos which performance platform depends on for development. `GOVUK_DEPS=1 ./install.sh`. The repos are listed in `GOV_REPOS`.
