### PR TITLE
Fix Vagrant issue when also running govuk dev VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 # Node definitions
 hosts = [
-  { name: 'development-1',  ip: '172.27.1.200' },
+  { name: 'pp-development-1',  ip: '10.0.0.100' },
 ]
 
 def get_box(provider)


### PR DESCRIPTION
"[pp-development-1] Clearing any previously set network interfaces...
The specified host network collides with a non-hostonly network!
This will cause your specified IP to be inaccessible. Please change
the IP or name of your host only network to not match that of
a bridged or non-hostonly network."

I also renamed the VM – not too attached to that change.
