### PR TITLE
Fix Vagrant file on Ubuntu with extra VM config

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,6 +43,7 @@ end
       c.ssh.forward_agent = true
       c.vm.provision :shell, :path => "tools/bootstrap-vagrant"
       c.vm.share_folder "apps", "/var/apps", ".."
+      c.vm.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/apps", "1"]
     end
   end
 end


### PR DESCRIPTION
On the following two Ubuntu systems, the "vagrant up" command failed
with an issue related to symlinks in Shared folders.
- Ubuntu 12.04 with vagrant-1.3.5 and VirtualBox 4.1.12
- Ubuntu 13.10 with vagrant-1.3.5 and Virtualbox 4.2.16

See the following discussion and fix:
- https://github.com/rodjek/librarian-puppet/issues/57
- https://github.com/mitchellh/vagrant/issues/713

@tombooth has tested that this doesn't adversely affect VirtualBox on Mac.
