### PR TITLE
Removed backdrop-ga-collector-private repo

### DIFF
--- a/GH_REPOS
+++ b/GH_REPOS
@@ -2,7 +2,6 @@ backdrop
 backdrop-asset-request-collector
 backdrop-collector
 backdrop-ga-collector
-backdrop-ga-collector-private
 backdrop-ga-realtime-collector
 backdrop-pingdom-collector
 backdrop-send


### PR DESCRIPTION
This repo has been replaced with backdrop-ga-collector
