### PR TITLE
Fail if Vagrant is too old

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,13 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+min_required_vagrant_version = '1.3.0'
+
+if Vagrant::VERSION < min_required_vagrant_version
+  $stderr.puts "ERROR: Puppet now requires Vagrant version >=#{min_required_vagrant_version}. Please upgrade.\n"
+  exit 1
+end
+
 # Node definitions
 hosts = [
   { name: 'pp-development-1',  ip: '10.0.0.100' },


### PR DESCRIPTION
Vagrant 1.3.0 is required for Hiera. As well as adding it to the README, we should make it really obvious by failing to do anything if your version of Vagrant is too old.
