### PR TITLE
Use NFS by default.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -85,7 +85,7 @@ end
 
       c.ssh.forward_agent = true
       c.vm.provision :shell, :path => "tools/bootstrap-vagrant"
-      c.vm.synced_folder "..", "/var/apps"
+      c.vm.synced_folder "..", "/var/apps", :nfs => true
     end
   end
 end


### PR DESCRIPTION
Much faster, due to known issue with Virtualbox shared folders:
http://docs-v1.vagrantup.com/v1/docs/nfs.html

See related pull request on pp-puppet: https://github.com/alphagov/pp-puppet/pull/247
