### PR TITLE
Add VirtualBox version detection to Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,8 +13,14 @@ def get_box(provider)
     name  = "puppetlabs-ubuntu-server-12042-x64-vf503-nocm"
     url   = "http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-svr-12042-x64-vf503-nocm.box"
   else
-    name  = "puppetlabs-ubuntu-server-12042-x64-vbox4210-nocm"
-    url   = "http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-12042-x64-vbox4210-nocm.box"
+    virtualBoxVersion = `vboxmanage --version`.strip
+    if virtualBoxVersion == "4.3.6r91406"
+      name = "pp-ubuntu-12.04-virtualbox-4.3.6r91406"
+      url = "https://s3-eu-west-1.amazonaws.com/gds-boxes/pp-ubuntu-12.04-virtualbox-4.3.6r91406.box"
+    else
+      name  = "puppetlabs-ubuntu-server-12042-x64-vbox4210-nocm"
+      url   = "http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-12042-x64-vbox4210-nocm.box"
+    end
   end
   return name, url
 end


### PR DESCRIPTION
The vagrant box will intelligently attempt to use an appropriate
base box that matches the installed version of VirtualBox.

Versions of VirtualBox older than 4.3.6 are assumed to be 4.2.
