### PR TITLE
Simplify bootstrap

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -84,10 +84,12 @@ while read repo; do
   fetch_repo "$repo" "$GITHUB_PUBLIC"
 done < "GH_REPOS"
 
-status "Reading list of private repositories from GHE_REPOS and fetching from GitHub Enterprise"
-while read repo; do
-  fetch_repo "$repo" "$GITHUB_ENT"
-done < "GHE_REPOS"
+if [ -n "$ENT_DEPS" ]; then
+    status "Reading list of private repositories from GHE_REPOS and fetching from GitHub Enterprise"
+    while read repo; do
+      fetch_repo "$repo" "$GITHUB_ENT"
+    done < "GHE_REPOS"
+fi
 
 if [ -n "$GOVUK_DEPS" ]; then
     status "Reading list of GOV.UK repositories from GOV_REPOS and fetching from GitHub"

--- a/tools/bootstrap-vagrant
+++ b/tools/bootstrap-vagrant
@@ -51,16 +51,13 @@ bundle_gems() {
   cd /var/apps/pp-puppet
   bundle --path vendor/bundle \
          --without NONEXISTENT \
-         --deployment \
-         --standalone \
-         --binstubs \
          --quiet 2>&1 | pp
 }
 
 install_modules() {
   echo "--> Update 3rd-party modules" | pp
   cd /var/apps/pp-puppet
-  bundle exec ./bin/librarian-puppet install >&2
+  bundle exec librarian-puppet install --destructive >&2
 }
 
 do_puppet_run() {
@@ -77,7 +74,7 @@ do_puppet_run() {
   fi
 
 
-  FACTER_machine_role=development ./bin/puppet apply --modulepath=modules:vendor/modules \
+  FACTER_machine_role=development bundle exec puppet apply --modulepath=modules:vendor/modules \
                      --hiera_config=../pp-development/hiera.yaml \
                      manifests/site.pp 2>&1 | pp
 }


### PR DESCRIPTION
_Only attempt to install GHE repos if requested_
This works in the same way as GOVUK_REPOS, with an environment variable. The reason for this is that SMEs using this repo will not have access to these repositories and therefore get a nasty error message.

_Simplify bootstrap-vagrant_
- Simplify how gems are installed
- Make librarian puppet install destructive so that broken cached modules are removed and reinstalled rather than staying broken.
