### PR TITLE
Get public repos over HTTPS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-GITHUB_PUBLIC="git@github.com:alphagov"
+GITHUB_PUBLIC="https://github.com/alphagov"
 GITHUB_ENT="git@github.gds:gds"
 
 ##############################################################################


### PR DESCRIPTION
Because otherwise we need to have a key set up, which is annoying for
doing automated testing etc.
