### PR TITLE
Be more explicit about required virtualbox version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ A Performance Platform development environment that uses [alphagov/pp-puppet](ht
 
 ## Host machine prerequisites
 
-- [Vagrant](http://www.vagrantup.com/) (we've tested with versions >= 1.3.0)
+- [Vagrant](http://www.vagrantup.com/) (note that vagrant >=1.4 is required to use VirtualBox >=4.3)
   - And the vagrant-dns plugin: `vagrant plugin install vagrant-dns`
 - Software to run the virtual machine
-  - We make heavy use of [VirtualBox](https://www.virtualbox.org/). The Guest Additions installed on the disk image we use are for 4.2.10, use this version if possible.
+  - An exact version of [VirtualBox](https://www.virtualbox.org/) for which there exists a [machine image in `$boxesByVersion` in the Vagrantfile](./Vagrantfile). At time of writing this means **4.3.6r91406** but more versions may be added in the future. Mixing versions of virtualbox and additions is unsupported.
   - [VMware](http://www.vmware.com/uk/) should also work
   - For shared folders we use NFS to improve performance. Linux users may need to install the following packages: ``nfs-kernel-server nfs-common portmap``
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,16 @@ hosts = [
   { name: 'pp-development-1',  ip: '10.0.0.100' },
 ]
 
+# Images are built for specific versions of virtualbox guest additions for now.
+# It has proven problematic to mix versions of virtualbox and guest additions
+# in the past and therefore they are pinned by what is available in this map.
+$boxesByVersion = {
+  "4.3.6r91406" => {
+    name: "pp-ubuntu-12.04-virtualbox-4.3.6r91406",
+    url: "https://s3-eu-west-1.amazonaws.com/gds-boxes/pp-ubuntu-12.04-virtualbox-4.3.6r91406.box",
+  },
+}
+
 def get_box(provider)
   provider    ||= "virtualbox"
   case provider
@@ -14,13 +24,13 @@ def get_box(provider)
     url   = "http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-svr-12042-x64-vf503-nocm.box"
   else
     virtualBoxVersion = `vboxmanage --version`.strip
-    if virtualBoxVersion == "4.3.6r91406"
-      name = "pp-ubuntu-12.04-virtualbox-4.3.6r91406"
-      url = "https://s3-eu-west-1.amazonaws.com/gds-boxes/pp-ubuntu-12.04-virtualbox-4.3.6r91406.box"
-    else
-      name  = "puppetlabs-ubuntu-server-12042-x64-vbox4210-nocm"
-      url   = "http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-12042-x64-vbox4210-nocm.box"
+    box = $boxesByVersion[virtualBoxVersion]
+    if box.nil?
+      $stderr.puts "Virtualbox version #{virtualBoxVersion} is not supported by pp-development. See README.md. Supported: #{$boxesByVersion.keys}"
+      exit 1
     end
+
+    name, url = box[:name], box[:url]
   end
   return name, url
 end


### PR DESCRIPTION
This reduces the possibility someone will try to use an unsupported version
of virtualbox with the machine image and hopefully fixes the documentation
which had the wrong version numbers in it.

xref #38, but that issue is not fully resolved yet.
