### PR TITLE
Use the screenshot-as-a-service start-app script

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-screenshot_as_a_service: ./run_in.sh ../screenshot-as-a-service node app.js
+screenshot_as_a_service: ./run_in.sh ../screenshot-as-a-service ./start-app.sh
 spotlight: ./run_in.sh ../spotlight ./start-app.sh
 backdrop_read: ./run_in.sh ../backdrop ./start-app.sh read 3038
 backdrop_write: ./run_in.sh ../backdrop ./start-app.sh write 3039


### PR DESCRIPTION
Please merge alphagov/screenshot-as-a-service#4 first.

This installs dependencies before running the app.

Fixes #42.
