### PR TITLE
Don't enable NFS shared directory by default

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -121,7 +121,7 @@ end
       c.vm.provision :shell, :path => "tools/bootstrap-vagrant"
 
       c.vm.provider :virtualbox do |vb, override|
-        override.vm.synced_folder "..", "/var/apps", :nfs => true
+        override.vm.synced_folder "..", "/var/apps", :nfs => false
       end
 
       c.vm.provider :vmware_fusion do |f, override|


### PR DESCRIPTION
Using NFS for VirtualBox shared folders gives a large speedup on OS X.

It doesn't appear to work on Linux, and definitely doesn't work on Windows.

This makes a pretty good case that NFS should not be enabled by default.
