### PR TITLE
Fix #38 clarify successful vagrant provision

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ A Performance Platform development environment that uses [alphagov/pp-puppet](ht
   /var/apps/pp-puppet/vendor/bundle/ruby/1.9.1/gems/librarian-puppet-0.9.13/lib/librarian/puppet/source/forge.rb:114:in `unlink': Directory not empty - /var/apps/pp-puppet/.tmp/librarian/cache/source/puppet/forge/3792e516e3ff92a0ef9f5e827f8e76eb/smarchive/archive/version/7663d0c47292d3c50eb71d008ed8a340 (Errno::ENOTEMPTY)
   ```
   If this happens, running `vagrant provision` again may fix it (issue [#36](https://github.com/alphagov/pp-development/issues/36)).
+- When provisioning has completed successfully you should see the line:
+  `[bootstrap] pp-development/tools/bootstrap-vagrant exit success`
 - SSH on to the virtual machine with `vagrant ssh`
 - Install dependencies for each required app in `/var/apps` by following the
   instructions in their README files

--- a/tools/bootstrap-vagrant
+++ b/tools/bootstrap-vagrant
@@ -10,6 +10,13 @@ pp() {
   done
 }
 
+print_green() {
+  local green="\033[32m"
+  local blue="\033[34m"
+  local reset="\033[0m"
+  echo -e "${blue}[bootstrap]${green} $@${reset}"
+}
+
 quieten_sudo() {
   echo "--> Set root profile to quieten sudo tty message" | pp
   echo '[[ $(test -t 0) ]] && mesg n' > /root/.profile
@@ -108,6 +115,7 @@ main() {
   install_modules
   do_puppet_run
   setup_virtualenv
+  print_green "pp-development/tools/bootstrap-vagrant exit success"
 }
 
 main


### PR DESCRIPTION
Now if the provisioning script completes, it prints a success message.

New users are taught through the docs to look for this message.

![image](https://f.cloud.github.com/assets/438648/2399035/4c12b188-a9fb-11e3-85d1-357b2091c7dc.png)

The fact that it wasn't clear what a correctly provisioned machine
looked like prevented me from knowing that my machine was broken
initially. I got the most excellemnt error message `No error message`,
which made me think everything had succeded initially.

Fixes #38
