### PR TITLE
Add backdrop-collector-plugins to GH_REPOS

### DIFF
--- a/GH_REPOS
+++ b/GH_REPOS
@@ -1,6 +1,7 @@
 backdrop
 backdrop-asset-request-collector
 backdrop-collector
+backdrop-collector-plugins
 backdrop-ga-collector
 backdrop-ga-realtime-collector
 backdrop-pingdom-collector

--- a/install.sh
+++ b/install.sh
@@ -55,6 +55,8 @@ fetch_repo () {
     done
     if [ $attempts -eq 4 ]; then
       warn "Failed $1 - clone failed, skipping"
+    else
+      ok "Cloned $1"
     fi
   fi
 }


### PR DESCRIPTION
A new repository was added and isn't currently fetched automatically.

I also added a new message to show that it is being cloned, because
I re-ran `./install.sh` and had no sign that it was being picked up.
