### PR TITLE
Add warning that VM is moving to pp-puppet

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,13 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+# Warning about VM moving to pp-puppet
+string_red = "\e[31m"
+string_reset = "\e[0m"
+puts string_red + "[WARNING] The Performance Platform virtual machine is now available in pp-puppet" + string_reset
+puts string_red + "[WARNING] The VM that you are using is deprecated and will be removed in future" + string_reset
+puts "\n"
+
 # Node definitions
 hosts = [
   { name: 'pp-development-1',  ip: '10.0.0.100' },


### PR DESCRIPTION
The dev VM is moving to pp-puppet in alphagov/pp-puppet#364.

We should warn people when they try to use this VM so that they have a change to migrate, and then we can remove this repo at some point in the future.

This should be merged soon after alphagov/pp-puppet#364.
